### PR TITLE
Fixing autocorrect popup layout issue

### DIFF
--- a/HPGrowingTextView.m
+++ b/HPGrowingTextView.m
@@ -253,7 +253,7 @@
         // if our new height is greater than the maxHeight
         // sets not set the height or move things
         // around and enable scrolling
-		if (newSizeH >= maxHeight)
+		if (newSizeH > maxHeight)
 		{
 			if(!internalTextView.scrollEnabled){
 				internalTextView.scrollEnabled = YES;


### PR DESCRIPTION
There is an issue where the native autocomplete popup was appearing
below the word being corrected and was being clipped by the bottom
edge of the text input view. I was able to repro this bug by typing a
few lines of text into the text box. Then setting the text in the
box to "". If, at this point I attempted to mistype a word, so that
the autocomplete would appear, it would show the autocomplete popup
as described above. The problem was that when the text input view
was the same size as the maximum growable size, we were setting
enableScrolling to YES. It should only be set to YES when the
text height is larger than the max growing height.
